### PR TITLE
ci: run pylint on pull requests

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,8 @@
 name: Pylint
 
-on: [push]
+on: 
+  push:
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Add pull_request as a trigger so linting issues are caught before landing on main.